### PR TITLE
Feature/skip unexist dataframe

### DIFF
--- a/Keras-RL_DQN_FX.ipynb
+++ b/Keras-RL_DQN_FX.ipynb
@@ -48,35 +48,29 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\"    def get_values_at(self, datetime):\\n        values = None\\n        try:\\n            values = self.data().loc[datetime]\\n        except KeyError: \\n            assert False # FXIME\\n            last_exists_datetime = get_last_exists_datetime(datetime) - np.timedelta64(dminute, 'm')\\n            get_values_at\\n        return values\\n\""
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "class HistData:\n",
     "    def __init__(self, date_range=None):\n",
     "        self.csv_path = 'USDJPY.hst_.csv'\n",
     "        self.csv_data = pd.read_csv(self.csv_path, index_col=0, parse_dates=True, header=0)\n",
     "        self.date_range = date_range\n",
+    "\n",
     "    def data(self):\n",
     "        if self.date_range is None:\n",
     "            return self.csv_data\n",
     "        else:\n",
     "            return self.csv_data[self.date_range]\n",
+    "\n",
     "    def max_value(self):\n",
     "        return self.data()[['High']].max()['High']\n",
+    "\n",
     "    def min_value(self):\n",
     "        return self.data()[['Low']].min()['Low']\n",
+    "\n",
     "    def dates(self):\n",
     "        return self.data().index.values\n",
+    "\n",
     "    def get_last_exist_datetime_recursively(self, datetime64_value):\n",
     "        try:\n",
     "            return self.data().loc[datetime64_value], datetime64_value\n",
@@ -85,16 +79,28 @@
     "                return self.data().iloc[0], self.data().index[0]\n",
     "            previous_datetime = datetime64_value - np.timedelta64(1, 'm')\n",
     "            return self.get_last_exist_datetime_recursively(previous_datetime)\n",
-    "'''    def get_values_at(self, datetime):\n",
-    "        values = None\n",
-    "        try:\n",
-    "            values = self.data().loc[datetime]\n",
-    "        except KeyError: \n",
-    "            assert False # FXIME\n",
-    "            last_exists_datetime = get_last_exists_datetime(datetime) - np.timedelta64(dminute, 'm')\n",
-    "            get_values_at\n",
-    "        return values\n",
-    "'''"
+    "        \n",
+    "    ''' 引数の日時を含む直後に存在する値を取得する '''\n",
+    "    def get_next_exist_datetime(self, datetime64_value):\n",
+    "        index_size = len(self.data())\n",
+    "        last_index = index_size - 1\n",
+    "        # KeyErrorは補足しない。範囲外にならないように学習の際に\n",
+    "        # `nb_max_episode_steps` を与える必要がある\n",
+    "        next_index = min(\\\n",
+    "             self.data().index.get_loc(datetime64_value) + 1, \\\n",
+    "             last_index)\n",
+    "        return self.data().iloc[next_index], self.data().index[next_index]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 現在の問題点その3\n",
+    "\n",
+    "一つ心配事は、土日等休場日も学習すべきかどうかである。おそらく、４８時間全く値動きがないことを学習しても仕方ないので、これは飛ばして良いと思う。問題はその次の数分の欠測である。欠測の間は値動き無しとして学習するのが良いのか、純粋に経過時間（分）で学習するのが良いのかは、明確な答えを持っていない。一旦、閾値までの間値動きがなければ、次の値動きまでスキップするようにしようと思う。\n",
+    "\n",
+    "↓ここから、上記問題に対処するためのタネ"
    ]
   },
   {
@@ -110,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -124,16 +130,16 @@
        " Close         84.39\n",
        " Volatility     2.00\n",
        " Name: 2010-09-03 23:00:00, dtype: float64,\n",
-       " numpy.datetime64('2010-09-03T23:00:00.000000'))"
+       " numpy.datetime64('2010-09-03T23:00:00.000000+0000'))"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "h.get_last_exist_datetime_recursively(np.datetime64('2010-09-03T23:00:00.000000'))"
+    "h.get_last_exist_datetime_recursively(np.datetime64('2010-09-03T23:01:00.000000'))"
    ]
   },
   {
@@ -147,7 +153,12 @@
     {
      "data": {
       "text/plain": [
-       "\"def ____get_last_exist_datetime_recursively(hist_data, datetime64_value):\\n    try:\\n        return h.data().loc[datetime64_value], datetime64_value\\n    except:\\n        #import pdb; pdb.set_trace()\\n        if hist_data.data().index[0] > datetime64_value:\\n            return hist_data.data().iloc[0], hist_data.data().index[0]\\n        previous_datetime = datetime64_value - np.timedelta64(1, 'm')\\n        return get_last_exist_datetime_recursively(hist_data, previous_datetime)\\n\\ndatetime = np.datetime64('2001-09-04 00:02:00')\\nget_last_exist_datetime_recursively(h, datetime)\""
+       "(Open          84.39\n",
+       " High          84.39\n",
+       " Low           84.38\n",
+       " Close         84.39\n",
+       " Volatility     2.00\n",
+       " Name: 2010-09-03 23:00:00, dtype: float64, Timestamp('2010-09-03 23:00:00'))"
       ]
      },
      "execution_count": 6,
@@ -156,18 +167,59 @@
     }
    ],
    "source": [
-    "'''def ____get_last_exist_datetime_recursively(hist_data, datetime64_value):\n",
-    "    try:\n",
-    "        return h.data().loc[datetime64_value], datetime64_value\n",
-    "    except:\n",
-    "        #import pdb; pdb.set_trace()\n",
-    "        if hist_data.data().index[0] > datetime64_value:\n",
-    "            return hist_data.data().iloc[0], hist_data.data().index[0]\n",
-    "        previous_datetime = datetime64_value - np.timedelta64(1, 'm')\n",
-    "        return get_last_exist_datetime_recursively(hist_data, previous_datetime)\n",
-    "\n",
-    "datetime = np.datetime64('2001-09-04 00:02:00')\n",
-    "get_last_exist_datetime_recursively(h, datetime)'''"
+    "h.get_next_exist_datetime(np.datetime64('2010-09-03T22:59:00.000000'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Open          84.16\n",
+       " High          84.16\n",
+       " Low           84.08\n",
+       " Close         84.13\n",
+       " Volatility     9.00\n",
+       " Name: 2010-09-06 00:00:00, dtype: float64, Timestamp('2010-09-06 00:00:00'))"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h.get_next_exist_datetime(np.datetime64('2010-09-03T23:00:00.000000'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Timedelta('2 days 01:00:00')"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "now = np.datetime64('2010-09-03T23:00:00.000000')\n",
+    "last_datetime, _ = h.get_last_exist_datetime_recursively(now)\n",
+    "next_exist_datetime, _ = h.get_next_exist_datetime(np.datetime64('2010-09-03T23:00:00.000000'))\n",
+    "next_exist_datetime.name - last_datetime.name"
    ]
   },
   {
@@ -191,6 +243,13 @@
    "source": [
     "datetime = np.datetime64('2001-09-04 00:32:00')\n",
     "pd.DatetimeIndex([datetime]).minute[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "↑ここまで、上記問題に対処するためのタネ"
    ]
   },
   {
@@ -263,20 +322,12 @@
     "        self._max_date = self._datetime2float(hist_data.dates().max())\n",
     "        self._min_date = self._datetime2float(hist_data.dates().min())\n",
     "        self._seed = seed_value\n",
-    "        #logger.debugger = logger\n",
-    "        #logger.debug(self._max_date, Loglevel.DEBUG)\n",
-    "        #logger.debug(self._min_date, Loglevel.DEBUG)\n",
     "\n",
     "        high = np.array([self._max_date, hist_data.max_value()])\n",
     "        low = np.array([self._min_date, hist_data.min_value()])\n",
     "        self.action_space = gym.spaces.Discrete(3)\n",
     "        self.observation_space = gym.spaces.Box(low = low, high = high) # DateFrame, Close prise\n",
-    "\n",
-    "    '''def _logger(self, text, loglevel=Loglevel.DEBUG):\n",
-    "        if logger.debugger is not None:\n",
-    "            logger.debugger.log(text, level=loglevel)'''\n",
     "        \n",
-    "    #@now_datetime.setter\n",
     "    def get_now_datetime_as(self, datetime_or_float):\n",
     "        if datetime_or_float == 'float':\n",
     "            return self._now_datetime\n",
@@ -284,7 +335,6 @@
     "            dt = self._float2datetime(self._now_datetime)\n",
     "            return dt\n",
     "    \n",
-    "    #@property\n",
     "    def _set_now_datetime(self, value):\n",
     "        if isinstance(value, float):\n",
     "            assert self._min_date <= value, value\n",
@@ -309,7 +359,6 @@
     "    \n",
     "    def _datetime2float(self, datetime64_value):\n",
     "        try:\n",
-    "            #import pdb; pdb.set_trace()\n",
     "            float_val = float(str(datetime64_value.astype('uint64'))[:10])\n",
     "            return float_val\n",
     "        except:\n",
@@ -318,7 +367,6 @@
     "    \n",
     "    def _float2datetime(self, float_timestamp):\n",
     "        try:\n",
-    "            #import pdb; pdb.set_trace()\n",
     "            datetime_val = np.datetime64(dt.datetime.utcfromtimestamp(float_timestamp))\n",
     "            return datetime_val\n",
     "        except:\n",
@@ -449,43 +497,13 @@
     "\n",
     "        self._set_now_datetime(self.hist_data.dates()[0])\n",
     "        print(self._now_datetime)\n",
+    "\n",
     "        self._now_buy_price = self.hist_data.data()['Close'][0]\n",
     "        self._positions = []\n",
     "        print(self._seed)\n",
     "        print('_reset END')\n",
     "        return np.array([self._now_datetime, self._now_buy_price])\n",
     "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2010-09-03T23:01:00.000000 (mod: 2010-09-03T23:00:00.000000) 84.390000\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(array([  1.28355486e+09,   8.43900000e+01]), 5212378.3278999999, False, {})"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "fxt = FXTrade(1000000, 0.08, h)\n",
-    "fxt._set_now_datetime(np.datetime64('2010-09-03T23:00:00.000000'))\n",
-    "fxt._step(1)"
    ]
   },
   {
@@ -1047,7 +1065,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/Keras-RL_DQN_FX.py
+++ b/Keras-RL_DQN_FX.py
@@ -33,17 +33,22 @@ class HistData:
         self.csv_path = 'USDJPY.hst_.csv'
         self.csv_data = pd.read_csv(self.csv_path, index_col=0, parse_dates=True, header=0)
         self.date_range = date_range
+
     def data(self):
         if self.date_range is None:
             return self.csv_data
         else:
             return self.csv_data[self.date_range]
+
     def max_value(self):
         return self.data()[['High']].max()['High']
+
     def min_value(self):
         return self.data()[['Low']].min()['Low']
+
     def dates(self):
         return self.data().index.values
+
     def get_last_exist_datetime_recursively(self, datetime64_value):
         try:
             return self.data().loc[datetime64_value], datetime64_value
@@ -52,16 +57,6 @@ class HistData:
                 return self.data().iloc[0], self.data().index[0]
             previous_datetime = datetime64_value - np.timedelta64(1, 'm')
             return self.get_last_exist_datetime_recursively(previous_datetime)
-'''    def get_values_at(self, datetime):
-        values = None
-        try:
-            values = self.data().loc[datetime]
-        except KeyError: 
-            assert False # FXIME
-            last_exists_datetime = get_last_exists_datetime(datetime) - np.timedelta64(dminute, 'm')
-            get_values_at
-        return values
-'''
 
 
 # In[4]:
@@ -72,22 +67,6 @@ h = HistData('2010/09')
 # In[5]:
 
 h.get_last_exist_datetime_recursively(np.datetime64('2010-09-03T23:00:00.000000'))
-
-
-# In[6]:
-
-'''def ____get_last_exist_datetime_recursively(hist_data, datetime64_value):
-    try:
-        return h.data().loc[datetime64_value], datetime64_value
-    except:
-        #import pdb; pdb.set_trace()
-        if hist_data.data().index[0] > datetime64_value:
-            return hist_data.data().iloc[0], hist_data.data().index[0]
-        previous_datetime = datetime64_value - np.timedelta64(1, 'm')
-        return get_last_exist_datetime_recursively(hist_data, previous_datetime)
-
-datetime = np.datetime64('2001-09-04 00:02:00')
-get_last_exist_datetime_recursively(h, datetime)'''
 
 
 # In[7]:
@@ -137,20 +116,12 @@ class FXTrade(gym.core.Env):
         self._max_date = self._datetime2float(hist_data.dates().max())
         self._min_date = self._datetime2float(hist_data.dates().min())
         self._seed = seed_value
-        #logger.debugger = logger
-        #logger.debug(self._max_date, Loglevel.DEBUG)
-        #logger.debug(self._min_date, Loglevel.DEBUG)
 
         high = np.array([self._max_date, hist_data.max_value()])
         low = np.array([self._min_date, hist_data.min_value()])
         self.action_space = gym.spaces.Discrete(3)
         self.observation_space = gym.spaces.Box(low = low, high = high) # DateFrame, Close prise
-
-    '''def _logger(self, text, loglevel=Loglevel.DEBUG):
-        if logger.debugger is not None:
-            logger.debugger.log(text, level=loglevel)'''
         
-    #@now_datetime.setter
     def get_now_datetime_as(self, datetime_or_float):
         if datetime_or_float == 'float':
             return self._now_datetime
@@ -158,7 +129,6 @@ class FXTrade(gym.core.Env):
             dt = self._float2datetime(self._now_datetime)
             return dt
     
-    #@property
     def _set_now_datetime(self, value):
         if isinstance(value, float):
             assert self._min_date <= value, value
@@ -183,7 +153,6 @@ class FXTrade(gym.core.Env):
     
     def _datetime2float(self, datetime64_value):
         try:
-            #import pdb; pdb.set_trace()
             float_val = float(str(datetime64_value.astype('uint64'))[:10])
             return float_val
         except:
@@ -192,7 +161,6 @@ class FXTrade(gym.core.Env):
     
     def _float2datetime(self, float_timestamp):
         try:
-            #import pdb; pdb.set_trace()
             datetime_val = np.datetime64(dt.datetime.utcfromtimestamp(float_timestamp))
             return datetime_val
         except:
@@ -321,6 +289,7 @@ class FXTrade(gym.core.Env):
 
         self._set_now_datetime(self.hist_data.dates()[0])
         print(self._now_datetime)
+
         self._now_buy_price = self.hist_data.data()['Close'][0]
         self._positions = []
         print(self._seed)


### PR DESCRIPTION
## 現在の問題点その3

一つ心配事は、土日等休場日も学習すべきかどうかである。おそらく、４８時間全く値動きがないことを学習しても仕方ないので、これは飛ばして良いと思う。問題はその次の数分の欠測である。欠測の間は値動き無しとして学習するのが良いのか、純粋に経過時間（分）で学習するのが良いのかは、明確な答えを持っていない。一旦、閾値までの間値動きがなければ、次の値動きまでスキップするようにしようと思う。

## 問題点その3へのアプローチ

存在しないデータフレームのインデックス（日時）が与えられた時、例外のエラーを吐く代わりに、（与えられた日時から見て）直近の未来のインデックス（日時）とその時の値群を返すメソッド `get_next_exist_dateframe()` を `HistData` クラスに作成。これで欠測値をスキップして値を取得できる。

## この後の予定

スキップするにしても、2分スキップするのと2日スキップするのとでは意味合いが異なってくる。閾値以下であればスキップし、そうでなければスキップせず「値動きがない」状態を学習するようにしてみる。どっちが良いのかはわからないので、一度動かしてみて、結果を見てフィードバックするのが良いか。