### PR TITLE
:+1: feature/create_method_is_datetime_diff_in_threshould

### DIFF
--- a/Keras-RL_DQN_FX.ipynb
+++ b/Keras-RL_DQN_FX.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -89,7 +89,14 @@
     "        next_index = min(\\\n",
     "             self.data().index.get_loc(datetime64_value) + 1, \\\n",
     "             last_index)\n",
-    "        return self.data().iloc[next_index], self.data().index[next_index]"
+    "        return self.data().iloc[next_index], self.data().index[next_index]\n",
+    "    \n",
+    "    ''' fromとtoの日時の差が閾値内にあるか否か '''\n",
+    "    def is_datetime_diff_in_threshould(self, from_datetime, to_datetime, threshold_timedelta):\n",
+    "        last_datetime, _ = h.get_last_exist_datetime_recursively(from_datetime)\n",
+    "        next_exist_datetime, _ = h.get_next_exist_datetime(to_datetime)\n",
+    "        delta = next_exist_datetime.name - last_datetime.name\n",
+    "        return delta <= threshold_timedelta"
    ]
   },
   {
@@ -98,103 +105,26 @@
    "source": [
     "## 現在の問題点その3\n",
     "\n",
-    "一つ心配事は、土日等休場日も学習すべきかどうかである。おそらく、４８時間全く値動きがないことを学習しても仕方ないので、これは飛ばして良いと思う。問題はその次の数分の欠測である。欠測の間は値動き無しとして学習するのが良いのか、純粋に経過時間（分）で学習するのが良いのかは、明確な答えを持っていない。一旦、閾値までの間値動きがなければ、次の値動きまでスキップするようにしようと思う。\n",
-    "\n",
-    "↓ここから、上記問題に対処するためのタネ"
+    "一つ心配事は、土日等休場日も学習すべきかどうかである。おそらく、４８時間全く値動きがないことを学習しても仕方ないので、これは飛ばして良いと思う。問題はその次の数分の欠測である。欠測の間は値動き無しとして学習するのが良いのか、純粋に経過時間（分）で学習するのが良いのかは、明確な答えを持っていない。一旦、閾値までの間値動きがなければ、次の値動きまでスキップするようにしようと思う。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 現在の問題点その3に対する解\n",
+    "時間のある時にきちんとチェックする必要があるが、Udacityの[Machine Learning for Trading](https://www.udacity.com/course/machine-learning-for-trading--ud501)では、休場中を特別な扱いはしていなかったような記憶がある（間違っていたら修正する必要がある）。したがって、メソッド `is_datetime_diff_in_threshould()` を作ったが、今は使わないでおくことにする。"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "h = HistData('2010/09')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(Open          84.39\n",
-       " High          84.39\n",
-       " Low           84.38\n",
-       " Close         84.39\n",
-       " Volatility     2.00\n",
-       " Name: 2010-09-03 23:00:00, dtype: float64,\n",
-       " numpy.datetime64('2010-09-03T23:00:00.000000+0000'))"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "h.get_last_exist_datetime_recursively(np.datetime64('2010-09-03T23:01:00.000000'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(Open          84.39\n",
-       " High          84.39\n",
-       " Low           84.38\n",
-       " Close         84.39\n",
-       " Volatility     2.00\n",
-       " Name: 2010-09-03 23:00:00, dtype: float64, Timestamp('2010-09-03 23:00:00'))"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "h.get_next_exist_datetime(np.datetime64('2010-09-03T22:59:00.000000'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(Open          84.16\n",
-       " High          84.16\n",
-       " Low           84.08\n",
-       " Close         84.13\n",
-       " Volatility     9.00\n",
-       " Name: 2010-09-06 00:00:00, dtype: float64, Timestamp('2010-09-06 00:00:00'))"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "h.get_next_exist_datetime(np.datetime64('2010-09-03T23:00:00.000000'))"
    ]
   },
   {
@@ -207,7 +137,7 @@
     {
      "data": {
       "text/plain": [
-       "Timedelta('2 days 01:00:00')"
+       "True"
       ]
      },
      "execution_count": 13,
@@ -216,45 +146,14 @@
     }
    ],
    "source": [
-    "now = np.datetime64('2010-09-03T23:00:00.000000')\n",
-    "last_datetime, _ = h.get_last_exist_datetime_recursively(now)\n",
-    "next_exist_datetime, _ = h.get_next_exist_datetime(np.datetime64('2010-09-03T23:00:00.000000'))\n",
-    "next_exist_datetime.name - last_datetime.name"
+    "from_dt = np.datetime64('2010-09-03T23:01:00.000000')\n",
+    "to_dt = np.datetime64('2010-09-03T23:00:00.000000')\n",
+    "h.is_datetime_diff_in_threshould(from_dt, to_dt, dt.timedelta(days=2, hours=1, seconds=1))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "32"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "datetime = np.datetime64('2001-09-04 00:32:00')\n",
-    "pd.DatetimeIndex([datetime]).minute[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "↑ここまで、上記問題に対処するためのタネ"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -265,7 +164,7 @@
        "'1.11.3'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -278,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -305,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -313,6 +212,8 @@
    "source": [
     "class FXTrade(gym.core.Env):\n",
     "    AMOUNT_UNIT = 50000\n",
+    "    THRESHOULD_TIME_DELTA = dt.timedelta(days=1)\n",
+    "    \n",
     "    def __init__(self, initial_cash, spread, hist_data, seed_value=100000, logger=None):\n",
     "        self.hist_data = hist_data\n",
     "        self.initial_cash = initial_cash\n",
@@ -422,7 +323,12 @@
     "        # 今注目している日時を更新\n",
     "        logger.debug('今注目している日時を更新')\n",
     "        #import pdb; pdb.set_trace()\n",
-    "        now_datetime = self.get_now_datetime_as('datetime') + np.timedelta64(dminute, 'm')\n",
+    "        previous_datetime = self.get_now_datetime_as('datetime')\n",
+    "        now_datetime = previous_datetime + np.timedelta64(dminute, 'm')\n",
+    "        \n",
+    "        if now_datetime != modified_now_datetime:\n",
+    "            assert self.hist_data.is_datetime_diff_in_threshould(previous, now_datetime, THRESHOULD_TIME_DELTA)\n",
+    "        \n",
     "        logger.debug('before')\n",
     "        logger.debug(now_datetime)\n",
     "        logger.debug(self._now_datetime)\n",
@@ -992,61 +898,6 @@
     "plt.xlabel(\"step\")\n",
     "plt.ylabel(\"pos\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 現在の問題点その2\n",
-    "2010年9月3日のデータは23:00:00迄しかなく、23:01:00を読み出そうとした時にエラーが発生している。適切にスキップする処理が必要か。"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 現在の問題点その2に対する解\n",
-    "\n",
-    "その日時におけるデータが存在しなければ、その直前のデータを参照すれば良い。つまり、 `23:01:00` の代わりに `23:00:00` を返せばこのエラーは出なくなる。与えた日時に直近でデータが存在する過去の日時とその時の価格のセットを返すメソッド `get_last_exist_datetime_recursively()` を作成した。\n",
-    "\n",
-    "２０１０年９月３日は平日（金曜日）、また米国の祝日でもなく、夏時間の切り替え日でもなかった。なぜデータが欠損しているかはわからない。元データを見るとこのまま土日へ突入したようである。\n",
-    "\n",
-    "```\n",
-    "2005-09-02 22:57:00,109.63,109.64,109.63,109.63,6.0\n",
-    "2005-09-02 22:58:00,109.64,109.65,109.63,109.63,8.0\n",
-    "2005-09-02 22:59:00,109.63,109.63,109.63,109.63,2.0\n",
-    "2005-09-05 00:02:00,109.63,109.63,109.63,109.63,2.0\n",
-    "2005-09-05 00:09:00,109.7,109.7,109.7,109.7,2.0\n",
-    "2005-09-05 00:11:00,109.69,109.69,109.69,109.69,2.0\n",
-    "2005-09-05 00:14:00,109.7,109.74,109.69,109.69,5.0\n",
-    "2005-09-05 00:16:00,109.7,109.71,109.7,109.71,3.0\n",
-    "2005-09-05 00:17:00,109.7,109.71,109.7,109.7,4.0\n",
-    "2005-09-05 00:18:00,109.71,109.71,109.7,109.7,3.0\n",
-    "2005-09-05 00:20:00,109.71,109.71,109.7,109.7,5.0\n",
-    "```\n",
-    "\n",
-    "一つ心配事は、土日等休場日も学習すべきかどうかである。おそらく、４８時間全く値動きがないことを学習しても仕方ないので、これは飛ばして良いと思う。問題はその次の数分の欠測である。欠測の間は値動き無しとして学習するのが良いのか、純粋に経過時間（分）で学習するのが良いのかは、明確な答えを持っていない。一旦、閾値までの間値動きがなければ、次の値動きまでスキップするようにしようと思う。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "h.data()['2010-09-03']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1065,7 +916,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## 現在の問題点その3

一つ心配事は、土日等休場日も学習すべきかどうかである。おそらく、４８時間全く値動きがないことを学習しても仕方ないので、これは飛ばして良いと思う。問題はその次の数分の欠測である。欠測の間は値動き無しとして学習するのが良いのか、純粋に経過時間（分）で学習するのが良いのかは、明確な答えを持っていない。一旦、閾値までの間値動きがなければ、次の値動きまでスキップするようにしようと思う。

### 現在の問題点その3に対する解

時間のある時にきちんとチェックする必要があるが、Udacityの[Machine Learning for Trading](https://www.udacity.com/course/machine-learning-for-trading--ud501)では、休場中を特別な扱いはしていなかったような記憶がある（間違っていたら修正する必要がある）。したがって、メソッド `is_datetime_diff_in_threshould()` を作ったが、今は使わないでおくことにする。